### PR TITLE
artifactory.{prod,internal} migration

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ logLevel := Level.Warn
 resolvers ++= Seq(
   Resolver.url(
     "Artifactory ivy",
-    url("http://artifactory.prod.livongo.com/artifactory/plugins-release-local")
+    url("https://artifactory.internal.livongo.com/artifactory/plugins-release-local")
   )(Resolver.ivyStylePatterns)
 )
 


### PR DESCRIPTION
Update artifactory.prod references to read from artifactory.internal instead. The repositories on artifactory.prod are being replicated over to artifactory.internal and readers should be able to find what they need there.