### PR TITLE
Update log4j version

### DIFF
--- a/akka/build.sbt
+++ b/akka/build.sbt
@@ -17,6 +17,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-slf4j" % versions.akka % "test",
   "org.scalatest" %% "scalatest" % versions.scalaTest % "test",
   "org.scalatestplus" %% "mockito-1-10" % "3.1.0.0" % "test",
-  "org.mockito" % "mockito-core" % "3.2.11" % "test",
+  "org.mockito" % "mockito-core" % "4.6.1" % "test",
   "ch.qos.logback" % "logback-classic" % "1.1.3" % "test"
 )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,6 @@
 object Dependencies {
   object versions {
-    val slf4j = "1.7.29"
+    val slf4j = "1.7.36"
     val logback = "1.2.3"
     val scalaTest = "3.1.0"
     val akka = "2.5.26"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,4 +19,4 @@ addSbtPlugin("com.updateimpact" % "updateimpact-sbt-plugin" % "2.1.3")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("livongo" %% "build-plugins" % "0.1.16")
+addSbtPlugin("livongo" %% "build-plugins" % "4.2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.4.0-livongo-0.2.0"
+version in ThisBuild := "2.4.0-livongo-0.2.1"


### PR DESCRIPTION
- Updated "org.mockito" % "mockito-core" % "3.2.11" to "4.6.1". Reason: version "3.2.11" is not available on Maven.
- Updated "livongo" %% "build-plugins" % "0.1.16" to "4.2.0". Reason: version "4.2.0" has SBT dependency check support.
- Updated SBT version "1.2.8" to "1.7.1". Reason: sbt server could not start on Apple M1 (ARM64).
- Update slf4j "1.7.29" to "1.7.36". Reason: security update.